### PR TITLE
Updated APP_URL to prevent redirect issues.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: lscr.io/linuxserver/bookstack
     container_name: bookstack
     environment:
-      # - APP_URL=https://<yourdomain>/ # Only needed if run behind a reverse proxy
+      - APP_URL=http://127.0.0.1:6543 # Change this to https://<yourdomain>/ when ran behind a reverse proxy.
       - PUID=1024 # The user ID of the current user
       - PGID=100 # The group ID of the current user
       - TZ=Europe/Amsterdam # The Timezone where you live


### PR DESCRIPTION
Docker sets APP_URL to your_external_ip:6875 when you don't set APP_URL. This then breaks redirects (e.g. /login) and links to CSS. When APP_URL is set to http://127.0.0.1:6543 this issue is mitigated. Reference: https://github.com/linuxserver/docker-bookstack/issues/81